### PR TITLE
Replace `inquirer2` dependency with `inquirer` package as `inquirer2` no longer exists on PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Replace inquirer2 depedency with inquirer package as inquirer2 no longer exists on PyPI 
+
 ## [3.3.1] - 2022-09-14
 ### Fixed
 - Report an error when using the `release` command without the `[Unreleased]` section being present

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Replace inquirer2 depedency with inquirer package as inquirer2 no longer exists on PyPI 
+- Replace `inquirer2` dependency with `inquirer` package as `inquirer2` no longer exists on PyPI 
 
 ## [3.3.1] - 2022-09-14
 ### Fixed

--- a/changelogmanager/cli.py
+++ b/changelogmanager/cli.py
@@ -164,35 +164,32 @@ def add(ctx: Mapping, change_type: str, message: str) -> None:
     prompts = []
     if not change_type:
         prompts.append(
-            {
-                "kind": "list",
-                "name": "change_type",
-                "message": "Specify the type of your change",
-                "choices": TypesOfChange,
-            }
+            inquirer.List(
+                name = "change_type",
+                message = "Specify the type of your change",
+                choices = TypesOfChange
+            )
         )
 
     if not message:
         prompts.append(
-            {
-                "kind": "text",
-                "name": "message",
-                "message": "Message of the changelog entry to add",
-            }
+            inquirer.Text(
+                name = "message",
+                message = "Message of the changelog entry to add"
+            )
         )
 
     if len(prompts) > 0:
-        changelog_entry = inquirer.prompt(inquirer.load_from_list(prompts))
-        apply = inquirer.prompt(inquirer.load_from_list(
+        changelog_entry = inquirer.prompt(prompts)
+        apply = inquirer.prompt(
             [
-                {
-                    "kind": "confirm",
-                    "name": "confirmation",
-                    "message": "Apply changes to your CHANGELOG.md",
-                    "default": True,
-                }
+                inquirer.Confirm(
+                    name = "confirmation",
+                    message = "Apply changes to your CHANGELOG.md",
+                    default = True
+                )
             ]
-        )).get("confirmation")
+        ).get("confirmation")
 
     changelog_entry.setdefault("change_type", change_type)
     changelog_entry.setdefault("message", message)

--- a/changelogmanager/cli.py
+++ b/changelogmanager/cli.py
@@ -17,7 +17,7 @@
 from typing import Mapping, Optional
 
 from click import group, option, pass_context, Choice, File
-import inquirer2.prompt
+import inquirer
 import llvm_diagnostics as logging
 
 from changelogmanager.change_types import TypesOfChange
@@ -165,7 +165,7 @@ def add(ctx: Mapping, change_type: str, message: str) -> None:
     if not change_type:
         prompts.append(
             {
-                "type": "list",
+                "kind": "list",
                 "name": "change_type",
                 "message": "Specify the type of your change",
                 "choices": TypesOfChange,
@@ -175,24 +175,24 @@ def add(ctx: Mapping, change_type: str, message: str) -> None:
     if not message:
         prompts.append(
             {
-                "type": "input",
+                "kind": "text",
                 "name": "message",
                 "message": "Message of the changelog entry to add",
             }
         )
 
     if len(prompts) > 0:
-        changelog_entry = inquirer2.prompt.prompt(prompts)
-        apply = inquirer2.prompt.prompt(
+        changelog_entry = inquirer.prompt(inquirer.load_from_list(prompts))
+        apply = inquirer.prompt(inquirer.load_from_list(
             [
                 {
-                    "type": "confirm",
+                    "kind": "confirm",
                     "name": "confirmation",
                     "message": "Apply changes to your CHANGELOG.md",
                     "default": True,
                 }
             ]
-        ).get("confirmation")
+        )).get("confirmation")
 
     changelog_entry.setdefault("change_type", change_type)
     changelog_entry.setdefault("message", message)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "keepachangelog==2.0.0.dev2",
         "urllib3>=1.25.11,<2",
         "llvm-diagnostics>=3.0.0,<4",
-        'inquirer2==1.0.0',
+        'inquirer>=3.4.0',
     ),
     setup_requires=(
         "setuptools_scm",


### PR DESCRIPTION
I don't know anything about the `inquirer2` package as it doesn't seem to exist. Therefore, I don't know why it was chosen or why `inquirer` was rejected. It may be that you would prefer a different package. I simply wanted to have an installable and working copy of this project and am passing my changes on. If you would like to do something different, feel free.