### PR TITLE
chore: remove repository specific SECURITY guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,0 @@
-## Reporting a Vulnerability
-
-If you discover a potential security issue in this project we ask that you notify the CODEOWNERS directly via email.
-
-Please do **not** create a public GitHub issue.


### PR DESCRIPTION
This will be replaced by an organization security guideline hosted in: https://github.com/tomtom-international/.github